### PR TITLE
Change references of generators/ to libnamegen/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,9 +137,6 @@ dmypy.json
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/docs/gentemplate.py
+++ b/docs/gentemplate.py
@@ -19,7 +19,7 @@ import os
 
 # the following two lines of code are not required since they are only for
 # requiring a file.
-if not os.path.isfile("generators/[requiredfile]"):
+if not os.path.isfile("libnamegen/[requiredfile]"):
     print("ERROR: [requiredfile] could not be found!")
 
 
@@ -32,7 +32,7 @@ def gen(count=1, debug=False):  # you may add more arguments after debug
     count -- the amount of names to generate (default 1)
     debug -- whether debug should be printed (default False)
     """
-    with open("generators/[requiredfile]") as f:  # use this block to read all
+    with open("libnamegen/[requiredfile]") as f:  # use this block to read all
         # the data in your file
         words = f.readlines()  # read the file
     words = [x.strip() for x in words]  # remove newlines, now each line in

--- a/libnamegen/__init__.py
+++ b/libnamegen/__init__.py
@@ -4,7 +4,7 @@ Name Generator Method Package.
 
 by BBaoVanC
 
-!!! THIS PACKAGE WILL NOT WORK IF YOUR PROGRAM IS IN generators/ !!!
+!!! THIS PACKAGE WILL NOT WORK IF YOUR PROGRAM IS IN libnamegen/ !!!
 This is a package which contains the various name generation methods used in
 https://github.com/BBaoVanC/NameGenerator
 

--- a/libnamegen/classic.py
+++ b/libnamegen/classic.py
@@ -20,7 +20,7 @@ import random
 import libprogress
 
 # following block is for a file requirement
-if not os.path.isfile("generators/desiquintans.com_nounlist.txt"):
+if not os.path.isfile("libnamegen/desiquintans.com_nounlist.txt"):
     print("ERROR: desiquintans.com_nounlist.txt could not be found!")
 
 
@@ -33,7 +33,7 @@ def gen(count=1, debug=False):
     count -- the amount of names to generate (default 1)
     debug -- whether debug should be printed (default False)
     """
-    with open("generators/desiquintans.com_nounlist.txt") as f:  # open file
+    with open("libnamegen/desiquintans.com_nounlist.txt") as f:  # open file
         words = f.readlines()  # read all lines into a list
         # closing the file is not required, the with block does that for us
     words = [x.strip("\n") for x in words]  # remove the "\n" from each word


### PR DESCRIPTION
This was causing an error with the classic generator. It was referring to the word list being stored in generators/ when it had been moved to libnamegen/.

Fixes #34 